### PR TITLE
Improve hero section responsiveness and add description

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders hero title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const titleElement = screen.getByText(/Anany Deep/i);
+  expect(titleElement).toBeInTheDocument();
 });

--- a/src/Sections/Hero/Hero.css
+++ b/src/Sections/Hero/Hero.css
@@ -21,16 +21,38 @@
     color: transparent;
 }
 
-.hero-discription {
-    width: 60%;
-    margin-top: 20px;
-    font-size: 1em;
-    font-weight: 300;
-    text-align: center;
-}
+  .hero-description {
+      width: 80%;
+      max-width: 40vw;
+      margin-top: 20px;
+      font-size: 1.1em;
+      font-weight: 300;
+      line-height: 1.5;
+      text-align: left;
+      opacity: 0;
+      animation: fadeInUp 1s ease forwards 0.5s;
+  }
 
-.hero-discription .text-type {
-    line-height: 1.5;
-    font-size: 18px;
-}
+  .hero-description-text {
+      line-height: 1.5;
+      font-size: 18px;
+  }
+
+  @media (max-width: 768px) {
+      .hero-description {
+          max-width: 80vw;
+          text-align: center;
+      }
+  }
+
+  @keyframes fadeInUp {
+      from {
+          opacity: 0;
+          transform: translateY(20px);
+      }
+      to {
+          opacity: 1;
+          transform: translateY(0);
+      }
+  }
 

--- a/src/Sections/Hero/index.jsx
+++ b/src/Sections/Hero/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Particles from '../../Particles/Particles';
 import './Hero.css';
-import TextType from '../../TextType/TextType';
 import SplitText from '../../SplitText/SplitText';
 
 const Hero = () => {
@@ -36,13 +35,12 @@ const Hero = () => {
               textAlign="center"
             />
           </div>
-          <div className="hero-discription">
-            <TextType
-              text={['Building delightful web experiences.']}
-              typingSpeed={50}
-              showCursor={true}
-              cursorCharacter="|"
-            />
+          <div className="hero-description">
+            <p className="hero-description-text">
+              Crafting engaging interfaces with React and modern CSS.<br />
+              Passionate about responsive design and user experience.<br />
+              Always exploring new technologies to bring ideas to life.
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replace hero description with responsive three-line intro
- Animate hero description and adjust styling to 40% viewport width
- Update unit test to check for hero title

## Testing
- `npm test -- --watchAll=false` *(fails: SyntaxError: Unexpected token 'export' in ogl)*

------
https://chatgpt.com/codex/tasks/task_e_689ae303eef48327b181afe28c5a4727